### PR TITLE
Update polyfill.number.toLocaleString.js

### DIFF
--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -93,7 +93,7 @@
                 sNum = transformForLocale['us'](sNum, options);
             }
             
-            if(options.currency) {
+            if(options && options.currency) {
 	            if(options.currencyDisplay=="code") {
 		            sNum+=" "+options.currency.toUpperCase();
 	            } else {


### PR DESCRIPTION
if no options are provided as argument to the call it will throw an error "undefined is not an object (evaluating 'options.currency')", to fix simply check the options variable like you do on if(options && options.minimumFractionDigits) { ... }
