### PR TITLE
Corrected support for de-CH and de-LI

### DIFF
--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -83,7 +83,7 @@
                 thousands: '\u0027'
             };
             
-            return replaceSeperators(sNum, seperators);
+            return replaceSeparators(sNum, seperators);
         };
 
         var transformForLocale = {

--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -76,6 +76,13 @@
 
             return replaceSeparators(sNum, seperators);
         };
+        
+        var apostrophThousDotDec = function(sNum) {
+            var seperators = {
+                decimal: '.',
+                thousands: '\u0027'
+            }
+        }
 
         var transformForLocale = {
             en: commaThousDotDec,
@@ -84,8 +91,8 @@
             de: dotThousCommaDec,
             "de-DE": dotThousCommaDec,
             "de-AT": dotThousCommaDec,
-            "de-CH": dotThousCommaDec,
-            "de-LI": dotThousCommaDec,
+            "de-CH": apostrophThousDotDec,
+            "de-LI": apostrophThousDotDec,
             "de-BE": dotThousCommaDec,
             ro: dotThousCommaDec,
             "ro-RO": dotThousCommaDec,

--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -82,7 +82,7 @@
                 decimal: '.',
                 thousands: '\u0027'
             }
-        }
+        };
 
         var transformForLocale = {
             en: commaThousDotDec,

--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -81,7 +81,7 @@
             var seperators = {
                 decimal: '.',
                 thousands: '\u0027'
-            }
+            };
             
             return replaceSeperators(sNum, seperators);
         };

--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -82,6 +82,8 @@
                 decimal: '.',
                 thousands: '\u0027'
             }
+            
+            return replaceSeperators(sNum, seperators);
         };
 
         var transformForLocale = {

--- a/polyfill.number.toLocaleString.spec.js
+++ b/polyfill.number.toLocaleString.spec.js
@@ -42,6 +42,13 @@ describe('number.toLocaleString(locale) polyfill', function() {
 
         expect(num.toLocaleString(locale)).toBe('1.234,5');
     });
+    
+    it("returns a string formatted in de-CH style (1'234.5) when passed de-CH", function() {
+        var num = 1234.5;
+        var locale = 'de-CH';
+        
+        expect(num.toLocaleString(locale)).toBe("1'234.5");
+    } 
 
     it('returns a formatted string based only on the language code in complex locale codes', function() {
         var num = 1234.5;

--- a/polyfill.number.toLocaleString.spec.js
+++ b/polyfill.number.toLocaleString.spec.js
@@ -48,7 +48,7 @@ describe('number.toLocaleString(locale) polyfill', function() {
         var locale = 'de-CH';
         
         expect(num.toLocaleString(locale)).toBe("1'234.5");
-    } 
+    });
 
     it('returns a formatted string based only on the language code in complex locale codes', function() {
         var num = 1234.5;


### PR DESCRIPTION
Added a new function (apostrophThousDotDec) for correct swiss locale separating. 