### PR TITLE
Properly format negative amounts

### DIFF
--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -29,6 +29,10 @@
 
         var renderFormat = function(template, props) {
             for (var prop in props) {
+                if (props[prop].indexOf('-') !== -1) {
+                    props[prop] = props[prop].replace('-', '');
+                    template = '-' + template;
+                }
                 template = template.replace("{{" + prop + "}}", props[prop]);
             }
 
@@ -76,13 +80,13 @@
 
             return replaceSeparators(sNum, seperators);
         };
-        
+
         var apostrophThousDotDec = function(sNum) {
             var seperators = {
                 decimal: '.',
                 thousands: '\u0027'
             };
-            
+
             return replaceSeparators(sNum, seperators);
         };
 

--- a/polyfill.number.toLocaleString.spec.js
+++ b/polyfill.number.toLocaleString.spec.js
@@ -42,11 +42,11 @@ describe('number.toLocaleString(locale) polyfill', function() {
 
         expect(num.toLocaleString(locale)).toBe('1.234,5');
     });
-    
+
     it("returns a string formatted in de-CH style (1'234.5) when passed de-CH", function() {
         var num = 1234.5;
         var locale = 'de-CH';
-        
+
         expect(num.toLocaleString(locale)).toBe("1'234.5");
     });
 
@@ -121,6 +121,7 @@ describe('number.toLocaleString(locale) polyfill', function() {
 
     it('returns currency properly formatted for the locale specified', function() {
         var num = 1234.56;
+        var negative_num = -1234.56;
         var style = "currency";
         var currency = "USD";
         var currencyDisplay = "symbol";
@@ -129,6 +130,11 @@ describe('number.toLocaleString(locale) polyfill', function() {
             style: style,
             currency: currency
         })).toBe("$1,234.56");
+
+        expect(negative_num.toLocaleString("en-US", {
+            style: style,
+            currency: currency
+        })).toBe("-$1,234.56");
 
         expect(num.toLocaleString("de-DE", {
             style: style,


### PR DESCRIPTION
We're using a modified version of this polyfill at [Breather](https://github.com/breather), so first off thanks!

The only place our tests were failing was around formatting negative amounts as currencies: `-1234.56` would be formatted as `$-1,234.56` instead of `-$1,234.56`.

This solution is fairly crude and simply moves the `-` symbol to the beginning of the string if a negative number is detected. It works for currencies where the currency symbol is at the beginning and shouldn't break currencies with different syntax AFAIK, but there could be something I'm overlooking here.

I should also note I didn't change the package number, as I wanted to check with the maintainer first, though I think it makes sense to approach this as a patch.

Happy for any and all feedback, but mostly wanted to open the PR as I found other open PRs helpful when using this polyfill  :)