### PR TITLE
Handle not supported currency symbols by showing code in uppercase

### DIFF
--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -280,7 +280,8 @@
 
             if(options && options.currency && options.style === "currency") {
                 var format = currencyFormats[mapMatch(currencyFormatMap, locale)];
-                if(options.currencyDisplay === "code") {
+                var symbol = currencySymbols[options.currency.toLowerCase()];
+                if(options.currencyDisplay === "code" || !symbol) {
                     sNum = renderFormat(format, {
                         num: sNum,
                         code: options.currency.toUpperCase()
@@ -288,7 +289,7 @@
                 } else {
                     sNum = renderFormat(format, {
                         num: sNum,
-                        code: currencySymbols[options.currency.toLowerCase()]
+                        code: symbol
                     });
                 }
             }

--- a/polyfill.number.toLocaleString.spec.js
+++ b/polyfill.number.toLocaleString.spec.js
@@ -189,4 +189,14 @@ describe('number.toLocaleString(locale) polyfill', function() {
             currency: "vnd"
         })).toBe("₫1,234.56");
     });
+
+    it('returns currency in uppercase if symbol is not found', function () {
+      var num = 1234.56;
+      var style = "currency";
+
+      expect(num.toLocaleString("de-DE", {
+        style: style,
+        currency: "xxx"
+      })).toBe("1.234,56 XXX");
+    });
 });


### PR DESCRIPTION
This commit is to handle cases where the currency symbol doesn't
exist in the map e.g. bitcoin and new crypto currencies